### PR TITLE
Temporary fix for #28 - provide file type for non file submission

### DIFF
--- a/src/services/SubmissionService.js
+++ b/src/services/SubmissionService.js
@@ -168,6 +168,8 @@ function * createSubmission (authUser, files, entity) {
     reqBody['payload']['filename'] = files.submission.name
   } else { // If the file URL is provided, handle accordingly
     reqBody['payload']['isFileSubmission'] = false
+    // Temporary code, until ticket #28 is resolved
+    reqBody['payload']['fileType'] = fileType
   }
 
   // Post to Bus API using Helper function


### PR DESCRIPTION
- If a submission is created by passing a file, everything is fine
- If a submission is created by passing a url, file type is not known. Due to this, submission processor faces issues.
- Setting file type to zip for now when a url is passed during submission creation.