### PR TITLE
changing challenge api version for local development

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   BUSAPI_URL: process.env.BUSAPI_URL || 'https://api.topcoder-dev.com/v5',
   KAFKA_ERROR_TOPIC: process.env.KAFKA_ERROR_TOPIC || 'error.notification',
-  CHALLENGEAPI_URL: process.env.CHALLENGEAPI_URL || 'https://api.topcoder-dev.com/v3/challenges',
+  CHALLENGEAPI_URL: process.env.CHALLENGEAPI_URL || 'https://api.topcoder-dev.com/v4/challenges',
   AUTH0_URL: process.env.AUTH0_URL, // Auth0 credentials for Submission Service
   AUTH0_AUDIENCE: process.env.AUTH0_AUDIENCE || 'https://www.topcoder.com',
   TOKEN_CACHE_TIME: process.env.TOKEN_CACHE_TIME,

--- a/config/test.js
+++ b/config/test.js
@@ -16,7 +16,7 @@ module.exports = {
     S3_BUCKET: process.env.S3_BUCKET_TEST || 'tc-testing-submissions' // S3 Bucket to which submissions need to be uploaded
   },
   BUSAPI_EVENTS_URL: 'https://api.topcoder-dev.com/v5/bus/events',
-  CHALLENGEAPI_URL: 'https://api.topcoder-dev.com/v3/challenges',
+  CHALLENGEAPI_URL: 'https://api.topcoder-dev.com/v4/challenges',
   esConfig: {
     ES_INDEX: process.env.ES_INDEX_TEST || 'submission-test',
     ES_TYPE: process.env.ES_TYPE_TEST || '_doc' // ES 6.x accepts only 1 Type per index and it's mandatory to define it

--- a/test/common/testData.js
+++ b/test/common/testData.js
@@ -575,7 +575,7 @@ const testChallengeAPIResponse = {
       }
     ]
   },
-  'version': 'v3'
+  'version': 'v4'
 }
 
 module.exports = {


### PR DESCRIPTION
Just challenge API URL change for local development. This is not a necessary candidate for immediate production deployment. These changes can stay in the `develop` branch till the next functional deployment of sub api v5.

FYI... during prod and dev deployment all env vars are coming from JSON file hosted at S3 buckets. So these files based configs are overridden.