### PR TITLE
Complete Download Submission Access Rules

### DIFF
--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -553,7 +553,10 @@ function * checkGetAccess (authUser, submission, parentSpan) {
         const reviewer = _.filter(currUserRoles, { role: 'Reviewer' })
 
         if (screener.length !== 0) { // User is Screener
-          const screeningPhase = _.filter(phases, { phaseType: 'Screening', phaseStatus: 'Scheduled' })
+          const screeningPhase = _.union(
+            _.filter(phases, { phaseType: 'Screening', phaseStatus: 'Open' }),
+            _.filter(phases, { phaseType: 'Screening', phaseStatus: 'Closed' })
+          )
 
           // Screening is not Opened / Closed
           if (screeningPhase.length !== 0) {

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -551,16 +551,14 @@ function * checkGetAccess (authUser, submission, parentSpan) {
         const screener = _.filter(currUserRoles, { role: 'Primary Screener' })
         const reviewer = _.filter(currUserRoles, { role: 'Reviewer' })
 
-        if (screener.length !== 0) {
-          // User is Screener
+        if (screener.length !== 0) { // User is Screener
           const screeningPhase = _.filter(phases, { phaseType: 'Screening', phaseStatus: 'Scheduled' })
 
           // Screening is not Opened / Closed
           if (screeningPhase.length !== 0) {
             throw new errors.HttpStatusError(403, 'You can access the submission only when Screening is open')
           }
-        } else if (reviewer.length !== 0) {
-          // User is Reviewer
+        } else if (reviewer.length !== 0) { // User is Reviewer
           const reviewPhase = _.filter(phases, { phaseType: 'Review', phaseStatus: 'Scheduled' })
 
           // Review is not Opened / Closed

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -460,6 +460,9 @@ function * checkCreateAccess (authUser, subEntity, parentSpan) {
 
 /*
  * Function to check user access to get a submission
+ * This function should throw an HttpStatusError
+ * if user cannot access submission
+ *
  * @param authUser Authenticated user
  * @param submission Submission Entity
  * @param {Object} parentSpan the parent Span object
@@ -493,7 +496,7 @@ function * checkGetAccess (authUser, submission, parentSpan) {
         error: ex.response.body
       })
       getChallengeResourcesSpan.setTag('error', true)
-      return false
+      throw new errors.HttpStatusError(500, `Error while accessing ${config.CHALLENGEAPI_URL}/${submission.challengeId}/resources`)
     } finally {
       getChallengeResourcesSpan.finish()
     }
@@ -513,7 +516,7 @@ function * checkGetAccess (authUser, submission, parentSpan) {
         error: ex.response.body
       })
       getChallengeDetailSpan.setTag('error', true)
-      return false
+      throw new errors.HttpStatusError(500, `Error while accessing ${config.CHALLENGEAPI_URL}?filter=id=${submission.challengeId}`)
     } finally {
       getChallengeDetailSpan.finish()
     }

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -525,6 +525,7 @@ function * checkGetAccess (authUser, submission, parentSpan) {
       // Fetch all roles of the User pertaining to the current challenge
       const currUserRoles = _.filter(resources.body.result.content, { properties: { Handle: authUser.handle } })
       const subTrack = challengeDetails.body.result.content[0].subTrack
+      const track = challengeDetails.body.result.content[0].track
       const phases = challengeDetails.body.result.content[0].allPhases
 
       // Check if the User is a Copilot/Manager/Observer
@@ -569,7 +570,8 @@ function * checkGetAccess (authUser, submission, parentSpan) {
           const appealsResponse = _.filter(phases, { phaseType: 'Appeals Response', 'phaseStatus': 'Closed' })
 
           // Appeals Response is not closed yet
-          if (appealsResponse.length === 0) {
+          // Do not check for end of Appeals Response for Design Challenges
+          if (appealsResponse.length === 0 && track !== 'DESIGN') {
             throw new errors.HttpStatusError(403, 'You cannot access other submissions before the end of Appeals Response phase')
           } else {
             const userSubmission = yield fetchFromES({ challengeId: submission.challengeId,

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -546,14 +546,21 @@ function * checkGetAccess (authUser, submission, parentSpan) {
         const screener = _.filter(currUserRoles, { role: 'Primary Screener' })
         const reviewer = _.filter(currUserRoles, { role: 'Reviewer' })
 
-        // User is either a Reviewer or Screener
-        if (screener.length !== 0 || reviewer.length !== 0) {
+        if (screener.length !== 0) {
+          // User is Screener
           const screeningPhase = _.filter(phases, { phaseType: 'Screening', phaseStatus: 'Scheduled' })
+
+          // Screening is not Opened / Closed
+          if (screeningPhase.length !== 0) {
+            throw new errors.HttpStatusError(403, 'You can access the submission only when Screening is open')
+          }
+        } else if (reviewer.length !== 0) {
+          // User is Reviewer
           const reviewPhase = _.filter(phases, { phaseType: 'Review', phaseStatus: 'Scheduled' })
 
-          // Neither Screening Nor Review is Opened / Closed
-          if (screeningPhase.length !== 0 && reviewPhase.length !== 0) {
-            throw new errors.HttpStatusError(403, 'You can access the submission only when Screening / Review is open')
+          // Review is not Opened / Closed
+          if (reviewPhase.length !== 0) {
+            throw new errors.HttpStatusError(403, 'You can access the submission only when Review is open')
           }
         } else {
           const appealsResponse = _.filter(phases, { phaseType: 'Appeals Response', 'phaseStatus': 'Closed' })

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -594,7 +594,7 @@ function * checkGetAccess (authUser, submission, parentSpan) {
     } else {
       // We don't have enough details to validate the access
       logger.debug('No enough details to validate the Permissions')
-      return true
+      throw new errors.HttpStatusError(500, 'Could not get challenge info!')
     }
   } finally {
     checkGetAccessSpan.finish()

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -559,7 +559,7 @@ function * checkGetAccess (authUser, submission, parentSpan) {
           )
 
           // Screening is not Opened / Closed
-          if (screeningPhase.length !== 0) {
+          if (screeningPhase.length === 0) {
             throw new errors.HttpStatusError(403, 'You can access the submission only when Screening is open')
           }
         } else if (reviewer.length !== 0) { // User is Reviewer

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -527,12 +527,17 @@ function * checkGetAccess (authUser, submission, parentSpan) {
       const subTrack = challengeDetails.body.result.content[0].subTrack
       const phases = challengeDetails.body.result.content[0].allPhases
 
-      // Check if the User is a Copilot
-      const copilot = _.filter(currUserRoles, { role: 'Copilot' })
-      // Copilot have access to all submissions regardless of Phases
-      if (copilot.length !== 0) {
+      // Check if the User is a Copilot/Manager/Observer
+      const superRoles = _.union(
+        _.filter(currUserRoles, { role: 'Copilot' }),
+        _.filter(currUserRoles, { role: 'Manager' }),
+        _.filter(currUserRoles, { role: 'Observer' })
+      )
+      // Copilot/Manager/Observer have access to all submissions regardless of Phases
+      if (superRoles.length !== 0) {
         return true
       }
+
       // Check for Reviewer / Submitter roles
       if (subTrack === 'FIRST_2_FINISH') {
         const iterativeReviewer = _.filter(currUserRoles, { role: 'Iterative Reviewer' })


### PR DESCRIPTION
* Fix access being granted on failed Challenge API calls
* Separate the access check made for screeners and reviewers
* Allow Manager/Observer to download all submissions
* Do not check for the end of Appeals Response phase for Design challenges
